### PR TITLE
Fix wildcard pattern in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .svn/
 migrate_working_dir/
 .fvm/
+.*/
 
 # IntelliJ related
 *.iml


### PR DESCRIPTION
This pull request fixes the wildcard pattern in the .gitignore file to include all files and directories. Previously, the pattern was missing the wildcard character, causing some files and directories to be excluded from version control. This fix ensures that all files and directories are properly ignored.